### PR TITLE
docs: add missing `add` argument

### DIFF
--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -8,7 +8,7 @@ Nuxt.js has created a TypeScript runtime wrapper under a dedicated package **`@n
 ## Installation
 
 ```sh
-yarn @nuxt/typescript-runtime
+yarn add @nuxt/typescript-runtime
 # OR
 npm install @nuxt/typescript-runtime
 ```


### PR DESCRIPTION
Hey there, great work on Nuxt 2.9!

I just noticed a little typo while migrating from 2.8 to 2.9:

```bash
yarn @nuxt/typescript-runtime
```

Should be:
```bash
yarn add @nuxt/typescript-runtime
```