### PR TITLE
fix(runtime): add missing generate cli option

### DIFF
--- a/packages/typescript-runtime/lib/args.js
+++ b/packages/typescript-runtime/lib/args.js
@@ -22,7 +22,7 @@ function getRootdirFromArgv () {
   const optionsWithValue = getCliOptionsWithValue()
 
   const isCliOption = (previousArg, currentArg) => {
-    return ['dev', 'build', 'start'].includes(currentArg) ||
+    return ['dev', 'build', 'start', 'generate'].includes(currentArg) ||
       currentArg[0] === '-' ||
       (previousArg && previousArg[0] === '-' && optionsWithValue.includes(previousArg))
   }


### PR DESCRIPTION
Could not generate with `nuxt-ts generate`:

```bash
⨯ Unable to compile TypeScript:                                                                20:05:55
error TS5058: The specified path does not exist: '~.../generate/tsconfig.json'.
error TS5058: The specified path does not exist: 'generate/tsconfig.json'.
```

Adding `generate` to the cli option fixes it 👍 