### PR TITLE
fix(types): extractCSS accepts object value

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -47,7 +47,9 @@ export interface NuxtConfigurationBuild {
       loaders: NuxtConfigurationLoaders
     }
   ): void
-  extractCSS?: boolean
+  extractCSS?: boolean | {
+    [key: string]: any
+  }
   filenames?: { [key in 'app' | 'chunk' | 'css' | 'img' | 'font' | 'video']?: (ctx: { isDev: boolean }) => string }
   friendlyErrors?: boolean
   hardSource?: boolean


### PR DESCRIPTION
Based on this line: https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js#L359

For example, this code does not work now (type checking):

```ts
build: {
    extractCSS: {
      ignoreOrder: true
    }
}
```