### PR TITLE
Fix Function API cookbook

### DIFF
--- a/docs/cookbook/components/script.function-api.ts
+++ b/docs/cookbook/components/script.function-api.ts
@@ -1,5 +1,4 @@
-import Vue from 'vue'
-import { computed, value } from 'vue-function-api'
+import { createComponent, computed, value } from 'vue-function-api'
 
 interface User {
   firstName: string
@@ -10,8 +9,10 @@ interface YourProps {
   user?: User
 }
 
-export default Vue.extend({
-  name: 'YourComponent',
+export default createComponent({
+  props: {
+    user: {},
+  },
 
   setup ({ user }: YourProps) {
     const fullName = computed(() => `${user.firstName} ${user.lastName}`)


### PR DESCRIPTION
Fixed for Vue.js 2.x and Function API v2.2.0.

In practice, an undefined check of the `user` is also required but is omitted.