### PR TITLE
fix(runtime): fix SyntaxError when node v8

### DIFF
--- a/packages/typescript-runtime/lib/resolve.js
+++ b/packages/typescript-runtime/lib/resolve.js
@@ -3,7 +3,7 @@ const path = require('path')
 function tryResolve (path) {
   try {
     return require.resolve(path)
-  } catch {
+  } catch (err) {
     return null
   }
 }


### PR DESCRIPTION
This PR fixes SyntaxError when node v8.

In Node8, typescript-runtime/lib/resolve.js throws `SyntaxError: Unexpected token` (see below).
Because node8 doesn't support [optional catch binding](https://github.com/tc39/proposal-optional-catch-binding). It is a part of es2019.

```
~~~~/node_modules/@nuxt/typescript-runtime/lib/resolve.js:6
  } catch {
          ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (~~~~/node_modules/@nuxt/typescript-runtime/lib/index.js:2:6)
```