### PR TITLE
feat: support node require options

### DIFF
--- a/packages/typescript-runtime/bin/nuxt-ts.js
+++ b/packages/typescript-runtime/bin/nuxt-ts.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 const path = require('path')
-const { resolveNuxtBin, getRootdirFromArgv, registerTSNode } = require('..')
+const { resolveNuxtBin, getRootdirFromArgv, registerTSNode, applyRequires } = require('..')
 
 function main () {
   const rootDir = getRootdirFromArgv()
   const tsConfigPath = path.resolve(rootDir, 'tsconfig.json')
+
+  applyRequires()
 
   registerTSNode(tsConfigPath)
 

--- a/packages/typescript-runtime/lib/args.js
+++ b/packages/typescript-runtime/lib/args.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const arg = require('arg')
 const { tryResolve } = require('./resolve')
 
 function getCliOptions () {
@@ -17,8 +18,18 @@ function getCliOptionsWithValue () {
     }, [])
 }
 
+function getNodeArgs () {
+  return arg({
+    '--require': [String],
+    '-r': '--require'
+  }, {
+    argv: process.argv.slice(2)
+  })
+}
+
 function getRootdirFromArgv () {
-  const args = process.argv.slice(2)
+  const args = getNodeArgs()
+
   const optionsWithValue = getCliOptionsWithValue()
 
   const isCliOption = (previousArg, currentArg) => {
@@ -27,11 +38,12 @@ function getRootdirFromArgv () {
       (previousArg && previousArg[0] === '-' && optionsWithValue.includes(previousArg))
   }
 
-  const rootDir = args.find((arg, i) => !isCliOption(args[i - 1], arg)) || '.'
+  const rootDir = args._.find((arg, i) => !isCliOption(args[i - 1], arg)) || '.'
 
   return path.resolve(process.cwd(), rootDir)
 }
 
 module.exports = {
+  getNodeArgs,
   getRootdirFromArgv
 }

--- a/packages/typescript-runtime/lib/index.js
+++ b/packages/typescript-runtime/lib/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   ...require('./resolve'),
   ...require('./args'),
+  ...require('./require'),
   registerTSNode: require('./register')
 }

--- a/packages/typescript-runtime/lib/require.js
+++ b/packages/typescript-runtime/lib/require.js
@@ -1,0 +1,14 @@
+const { getNodeArgs } = require('./args')
+
+function applyRequires () {
+  const nodeArgs = getNodeArgs()
+  const requireOptions = nodeArgs['--require']
+  if (requireOptions && requireOptions.length) {
+    requireOptions.forEach(arg => require(arg))
+    process.argv = process.argv.filter(arg => !['--require', '-r'].includes(arg) && requireOptions && !requireOptions.includes(arg))
+  }
+}
+
+module.exports = {
+  applyRequires
+}


### PR DESCRIPTION
Nice to meet you.
Please point out if you have any commit rules etc.

This pull request is added to use -r option of node.js and ts-node.

The main library I wanted to use was tsconfig-paths.

```
"build": "node -r tsconfig-paths/register ./node_modules/@nuxt/typescript-runtime/bin/nuxt-ts.js build",
```

For example, how to use
```
"build": "nuxt-ts -r tsconfig-paths/register build"
```
Although it can be specified like this, I think that it will be convenient if you can also support it officially, so by making it possible to pass the -r option generically, I made this Pull Request so that other libraries can also be used It was.
I hope you can hire it.

Thank you