### PR TITLE
fix(types): add typing for Routes meta

### DIFF
--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -20,6 +20,7 @@ declare module 'vue/types/options' {
     transition?: string | Transition | ((to: Route, from: Route) => string)
     validate?(ctx: Context): Promise<boolean> | boolean
     watchQuery?: boolean | string[]
+    meta?: { [key: string]: any }
   }
 }
 


### PR DESCRIPTION
Add support for declaring the meta object in Nuxt.js Page, as we can see here https://github.com/nuxt/nuxt.js/tree/dev/examples/routes-meta 🤓 .