### PR TITLE
fix(types): add missing typings for NuxtApp interface

### DIFF
--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -92,4 +92,5 @@ export interface NuxtApp extends Vue {
   error(params: NuxtError): void
   isOffline: boolean
   isOnline: boolean
+  refresh(): void  
 }

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -89,6 +89,7 @@ export interface NuxtAppOptions extends ComponentOptions<Vue> {
 export interface NuxtApp extends Vue {
   $options: NuxtAppOptions
   $loading: NuxtLoading
+  context: Context
   error(params: NuxtError): void
   isOffline: boolean
   isOnline: boolean

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -93,8 +93,9 @@ export interface NuxtApp extends Vue {
   error(params: NuxtError): void
   isOffline: boolean
   isOnline: boolean
-  layout: any  // TBD
-  loadLayout(layout: string): Promise<any>  // TBD
+  layout: any // TBD
+  layoutName: string
+  loadLayout(layout: string): Promise<any> // TBD
   refresh(): void
-  setLayout(layout: string): any  // TBD
+  setLayout(layout: string): any // TBD
 }

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -93,6 +93,7 @@ export interface NuxtApp extends Vue {
   error(params: NuxtError): void
   isOffline: boolean
   isOnline: boolean
+  layout: any  // TBD
   loadLayout(layout: string): Promise<any>  // TBD
   refresh(): void
   setLayout(layout: string): any  // TBD

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -92,5 +92,7 @@ export interface NuxtApp extends Vue {
   error(params: NuxtError): void
   isOffline: boolean
   isOnline: boolean
-  refresh(): void  
+  loadLayout(layout: string): Promise<any>  // TBD
+  refresh(): void
+  setLayout(layout: string): any  // TBD
 }


### PR DESCRIPTION
- `$nuxt.refresh()`introduced in 2.9.0 [here](https://github.com/nuxt/nuxt.js/pull/6194)
- xxx introduced here / xxx implemented here