### PR TITLE
feat: ts-loader options

### DIFF
--- a/packages/typescript-build/lib/module.js
+++ b/packages/typescript-build/lib/module.js
@@ -41,7 +41,8 @@ function tsModule (_moduleOptions) {
             loader: 'ts-loader',
             options: {
               transpileOnly: true,
-              [`append${ext.charAt(0).toUpperCase() + ext.slice(1)}SuffixTo`]: [/\.vue$/]
+              [`append${ext.charAt(0).toUpperCase() + ext.slice(1)}SuffixTo`]: [/\.vue$/],
+              ...(moduleOptions.loaders && moduleOptions.loaders[ext])
             }
           }
         ]


### PR DESCRIPTION
Resolves #76

# Usage

```js
// nuxt.config.js

export default {
  typescript: {
    loaders: {
      ts: {
        // Use https://github.com/TypeStrong/ts-loader#options
      },
      tsx: {
        // Use https://github.com/TypeStrong/ts-loader#options
      }
    }
  }
}
```