### PR TITLE
fix(types): update types to match documentation examples

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,4 +1,4 @@
 import './process'
 
-export { Context, Middleware, Plugin, Transition } from './app'
+export { Context, Middleware, NuxtAppOptions, Plugin, Transition } from './app'
 export { Configuration, Module, ServerMiddleware } from './config'


### PR DESCRIPTION
Documentation examples have this code for extending `NuxtAppOptions`:

```
declare module '@nuxt/types' {
  interface NuxtAppOptions {
    $myInjectedFunction(message: string): void
  }
}
```

but that didn't work as `NuxtAppOptions` was not exported from
`types/index.d.ts`. So one had to either use `'@nuxt/types/app'`
module name or it wouldn't work.

For consistency with `Context`, I chose to export `NuxtAppOptions`.