### PR TITLE
docs: add Store interface extend for combined inject

### DIFF
--- a/docs/cookbook/plugins.md
+++ b/docs/cookbook/plugins.md
@@ -88,6 +88,12 @@ declare module '@nuxt/types' {
   }
 }
 
+declare module 'vuex/types/index' {
+  interface Store<S> {
+    $myInjectedFunction(message: string): void
+  }
+}
+
 const myPlugin: Plugin = (context, inject) => {
   inject('myInjectedFunction', (message: string) => console.log(message))
 }


### PR DESCRIPTION
Since `inject` injects object also in Store, example should have
types extending the store.