### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest": "latest",
     "lerna": "latest",
     "nuxt-edge": "latest",
-    "typescript": "~3.5",
+    "typescript": "latest",
     "vue-property-decorator": "latest"
   }
 }


### PR DESCRIPTION
Related issues are now closed and resolved so it should be on latest:
[Typescript](https://github.com/microsoft/TypeScript/issues/33164)
[Vue](https://github.com/vuejs/vue/issues/10455)

It's just a revert of this commit: https://github.com/nuxt/typescript/issues/98, the problem with this solutions is that it was missing in peerDeps so when somebody added devDep for `typescript "^3.6"`, it wasn't able to find the loader for nuxt.