### PR TITLE
fix(types): export NuxtError to be able to annotate error prop

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,4 +1,4 @@
 import './process'
 
-export { Context, Middleware, NuxtAppOptions, Plugin, Transition } from './app'
+export { Context, Middleware, NuxtAppOptions, NuxtError, Plugin, Transition } from './app'
 export { Configuration, Module, ServerMiddleware } from './config'


### PR DESCRIPTION
Error layout receives error object through a prop. To be able to
annotate that prop, we need NuxtError be exported.

Example error layout you can see here (javascript but it still applies):
https://medium.com/@mavrickmaster/custom-error-pages-with-nuxt-js-3c70e6c51aff#95d8