### PR TITLE
fix(types): allow no return in asyncData

### DIFF
--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -9,7 +9,7 @@ import { Context, Middleware, Transition, NuxtApp } from './index'
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
-    asyncData?(ctx: Context): object | undefined
+    asyncData?(ctx: Context): Promise<object> | Promise<void> | object | void
     fetch?(ctx: Context): Promise<void> | void
     head?: MetaInfo | (() => MetaInfo)
     key?: string | ((to: Route) => string)

--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -9,7 +9,7 @@ import { Context, Middleware, Transition, NuxtApp } from './index'
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
-    asyncData?(ctx: Context): Promise<object> | Promise<void> | object | void
+    asyncData?(ctx: Context): Promise<object | void> | object | void
     fetch?(ctx: Context): Promise<void> | void
     head?: MetaInfo | (() => MetaInfo)
     key?: string | ((to: Route) => string)


### PR DESCRIPTION
asyncData can be used to, for example decide if the page should
redirect or other things than returning a data object. Having no `void`
return type forces me to have a `return` statement at the end of function
body which looks weird and is unnecessary.