### PR TITLE
fix(types): add isModern type definition to build.filenames context

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -49,7 +49,7 @@ export interface NuxtConfigurationBuild {
     }
   ): void
   extractCSS?: boolean | Record<string, any>
-  filenames?: { [key in 'app' | 'chunk' | 'css' | 'img' | 'font' | 'video']?: (ctx: { isDev: boolean }) => string }
+  filenames?: { [key in 'app' | 'chunk' | 'css' | 'img' | 'font' | 'video']?: (ctx: { isDev: boolean, isModern: boolean }) => string }
   friendlyErrors?: boolean
   hardSource?: boolean
   hotMiddleware?: WebpackHotMiddlewareOptions


### PR DESCRIPTION
![Screen Shot 2019-09-17 at 2 43 24 PM](https://user-images.githubusercontent.com/4948562/65017501-85b41880-d959-11e9-87aa-197a3b7144f8.png)

For this purpose, I add { isModern } at  NuxtConfigurationBuild - filenames - ctx