### PR TITLE
fix(types): Add prefix property to NuxtConfigurationServerMiddleware

### DIFF
--- a/packages/types/config/server-middleware.d.ts
+++ b/packages/types/config/server-middleware.d.ts
@@ -7,4 +7,4 @@ import { RequestHandler } from 'express'
 
 export type ServerMiddleware = RequestHandler
 
-export type NuxtConfigurationServerMiddleware = string | { path: string, prefix?: boolean, handler: string | Function } | ServerMiddleware
+export type NuxtConfigurationServerMiddleware = string | { path: string, prefix?: boolean, handler: string | ServerMiddleware } | ServerMiddleware

--- a/packages/types/config/server-middleware.d.ts
+++ b/packages/types/config/server-middleware.d.ts
@@ -7,4 +7,4 @@ import { RequestHandler } from 'express'
 
 export type ServerMiddleware = RequestHandler
 
-export type NuxtConfigurationServerMiddleware = string | { path: string, handler: string | Function } | ServerMiddleware
+export type NuxtConfigurationServerMiddleware = string | { path: string, prefix?: boolean, handler: string | Function } | ServerMiddleware


### PR DESCRIPTION
This prefix is present in the documentation at https://nuxtjs.org/api/configuration-servermiddleware/ and in the code at https://github.com/nuxt/nuxt.js/blob/dev/packages/server/src/server.js#L202