### PR TITLE
docs(ja): fix store page

### DIFF
--- a/docs/ja/cookbook/store.md
+++ b/docs/ja/cookbook/store.md
@@ -77,6 +77,8 @@ Nuxt で使用するために重要な条件がいくつかあります：
    export function initializeAxios(axiosInstance: NuxtAxiosInstance) {
      $axios = axiosInstance
    }
+   
+   export { $axios }
    ```
 
    `~/store/users.ts`:


### PR DESCRIPTION
I fixed the cookbook code of `vuex-module-decorators` in the Japanese documentation.