### PR TITLE
feat(types): add types for NuxtConfigurationLoaders

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -31,36 +31,36 @@ type CssLoaderUrlFunction = (url: string, resourcePath: string) => boolean
 type CssLoaderImportFunction = (parsedImport: string, resourcePath: string) => boolean
 type CssLoaderMode = 'global' | 'local'
 interface CssLoaderModulesOptions {
-  mode?: CssLoaderMode
-  localIdentName?: string
   context?: string
-  hashPrefix?: string
   getLocalIdent?: (context: string, localIdentName: string, localName: string, options: CssLoaderModulesOptions) => string
+  hashPrefix?: string
+  localIdentName?: string
   localIdentRegExp?: string | RegExp
+  mode?: CssLoaderMode
 }
 
 interface CssLoaderOptions {
-  url?: boolean | CssLoaderUrlFunction
   import?: boolean | CssLoaderImportFunction
-  modules?: boolean | CssLoaderMode | CssLoaderModulesOptions
-  sourceMap?: boolean
   importLoaders?: number
   localsConvention?: 'asIs' | 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
+  modules?: boolean | CssLoaderMode | CssLoaderModulesOptions
   onlyLocals?: boolean
+  sourceMap?: boolean
+  url?: boolean | CssLoaderUrlFunction
 }
 
 interface NuxtConfigurationLoaders {
+  css?: CssLoaderOptions
+  cssModules?: CssLoaderOptions
   file?: FileLoaderOptions
   fontUrl?: FileLoaderOptions
   imgUrl?: FileLoaderOptions
-  pugPlain?: PugOptions
-  vue?: VueLoaderOptions
-  css?: CssLoaderOptions
-  cssModules?: CssLoaderOptions
   less?: Less.Options
+  pugPlain?: PugOptions
   sass?: SassOptions
   scss?: SassOptions
   stylus?: any // TBD
+  vue?: VueLoaderOptions
   vueStyle?: {
     manualInject?: boolean
     ssrId?: boolean

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -17,7 +17,7 @@ import { Options as OptimizeCssAssetsWebpackPluginOptions } from 'optimize-css-a
 import { TerserPluginOptions } from 'terser-webpack-plugin'
 import { Options as FileLoaderOptions } from 'file-loader'
 import { Options as PugOptions } from 'pug'
-import { Options as LessOptions } from 'less'
+import * as Less from 'less'
 import { Options as SassOptions } from 'node-sass'
 import { VueLoaderOptions } from 'vue-loader'
 
@@ -57,7 +57,7 @@ interface NuxtConfigurationLoaders {
   vue?: VueLoaderOptions
   css?: CssLoaderOptions
   cssModules?: CssLoaderOptions
-  less?: LessOptions
+  less?: Less.Options
   sass?: SassOptions
   scss?: SassOptions
   stylus?: any // TBD

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -15,8 +15,58 @@ import { Options as WebpackHotMiddlewareOptions } from 'webpack-hot-middleware'
 import { Options as HtmlMinifierOptions } from 'html-minifier'
 import { Options as OptimizeCssAssetsWebpackPluginOptions } from 'optimize-css-assets-webpack-plugin'
 import { TerserPluginOptions } from 'terser-webpack-plugin'
+import { Options as FileLoaderOptions } from 'file-loader'
+import { Options as PugOptions } from 'pug'
+import { Options as LessOptions } from 'less'
+import { Options as SassOptions } from 'node-sass'
+import { VueLoaderOptions } from 'vue-loader'
 
-type NuxtConfigurationLoaders = any // TBD
+interface FileLoaderOptions {
+  fallback?: string
+  limit?: number | boolean | string
+  mimetype?: string
+}
+
+type CssLoaderUrlFunction = (url: string, resourcePath: string) => boolean
+type CssLoaderImportFunction = (parsedImport: string, resourcePath: string) => boolean
+type CssLoaderMode = 'global' | 'local'
+interface CssLoaderModulesOptions {
+  mode?: CssLoaderMode
+  localIdentName?: string
+  context?: string
+  hashPrefix?: string
+  getLocalIdent?: (context: string, localIdentName: string, localName: string, options: CssLoaderModulesOptions) => string
+  localIdentRegExp?: string | RegExp
+}
+
+interface CssLoaderOptions {
+  url?: boolean | CssLoaderUrlFunction
+  import?: boolean | CssLoaderImportFunction
+  modules?: boolean | CssLoaderMode | CssLoaderModulesOptions
+  sourceMap?: boolean
+  importLoaders?: number
+  localsConvention?: 'asIs' | 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
+  onlyLocals?: boolean
+}
+
+interface NuxtConfigurationLoaders {
+  file?: FileLoaderOptions
+  fontUrl?: FileLoaderOptions
+  imgUrl?: FileLoaderOptions
+  pugPlain?: PugOptions
+  vue?: VueLoaderOptions
+  css?: CssLoaderOptions
+  cssModules?: CssLoaderOptions
+  less?: LessOptions
+  sass?: SassOptions
+  scss?: SassOptions
+  stylus?: any // TBD
+  vueStyle?: {
+    manualInject?: boolean
+    ssrId?: boolean
+    shadowMode?: boolean
+  }
+}
 
 interface NuxtBabelPresetEnv {
   isServer: boolean

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
-    "vue-loader": "^15.7.2"
+  "peerDependencies": {
+    "vue-loader": "*"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,9 +14,13 @@
     "@types/connect": "^3.4.32",
     "@types/etag": "^1.8.0",
     "@types/express": "^4.17.2",
+    "@types/file-loader": "^4.2.0",
     "@types/html-minifier": "^3.5.3",
+    "@types/less": "^3.0.1",
     "@types/node": "^12.12.11",
+    "@types/node-sass": "^4.11.0",
     "@types/optimize-css-assets-webpack-plugin": "^5.0.1",
+    "@types/pug": "^2.0.4",
     "@types/serve-static": "^1.13.3",
     "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack": "^4.41.0",
@@ -26,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "vue-loader": "^15.7.2"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,8 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "peerDependencies": {
-    "vue-loader": "*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,6 +2203,13 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/file-loader@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/file-loader/-/file-loader-4.2.0.tgz#ec8e793e275b7f90cdec3ff286518c6bf7bb8fc3"
+  integrity sha512-N3GMqKiKSNd41q4/lZlkdvNXKKWVdOXrA8Rniu64+25X0K2U1mWmTSu1CIqXKKsZUCwfaFcaioviLQtQ+EowLg==
+  dependencies:
+    "@types/webpack" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -2253,6 +2260,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/less@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/less/-/less-3.0.1.tgz#625694093c72f8356c4042754e222407e50d6b08"
+  integrity sha512-dBp05MtWN/w1fGVjj5LVrDw6VrdYllpWczbUkCsrzBj08IHsSyRLOFvUrCFqZFVR+nsqkrRLNg6oOlvqMLPaSA==
+
 "@types/memory-fs@*":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@types/memory-fs/-/memory-fs-0.3.2.tgz#5d4753f9b390cb077c8c8af97bc96463399ceccd"
@@ -2270,6 +2282,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/node-sass@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node-sass/-/node-sass-4.11.0.tgz#b0372075546e83f39df52bd37359eab00165a04d"
+  integrity sha512-uNpVWhwVmbB5luE7b8vxcJwu5np75YkVTBJS0O3ar+hrxqLfyhOKXg9NYBwJ6mMQX/V6/8d6mMZTB7x2r5x9Bw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@>= 8", "@types/node@^12.0.2", "@types/node@^12.12.11":
   version "12.12.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.11.tgz#bec2961975888d964196bf0016a2f984d793d3ce"
@@ -2286,6 +2305,11 @@
   integrity sha512-qyi5xmSl+DTmLFtVtelhso3VnNQYxltfgMa+Ed02xqNZCZBD0uYR6i64FmcwfieDzZRdwkJxt9o2JHq/5PBKQg==
   dependencies:
     "@types/webpack" "*"
+
+"@types/pug@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
+  integrity sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=
 
 "@types/q@^1.5.1":
   version "1.5.2"


### PR DESCRIPTION
Based on the documentation available here: https://nuxtjs.org/api/configuration-build/#loaders

**Notes:**
* Uses the packages' own types wherever possible, with `css-loader` and `vue-style-loader` being the notable exceptions.
* No types for [`stylus-loader`](https://www.npmjs.com/package/stylus-loader) - nor am I planning to do so.
* Adds vue-loader (which comes with its own types) to peerDependencies - is there a better way to do this?