### PR TITLE
fix(types): add correct url-loader options

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -5,6 +5,7 @@
 
 import {
   Configuration as WebpackConfiguration,
+  Loader as WebpackLoader,
   Options as WebpackOptions,
   Plugin as WebpackPlugin
 } from 'webpack'
@@ -49,12 +50,19 @@ interface CssLoaderOptions {
   url?: boolean | CssLoaderUrlFunction
 }
 
+interface UrlLoaderOptions {
+  esModules?: boolean
+  fallback?: WebpackLoader
+  limit?: boolean | number | string
+  mimetype?: string
+}
+
 interface NuxtConfigurationLoaders {
   css?: CssLoaderOptions
   cssModules?: CssLoaderOptions
   file?: FileLoaderOptions
-  fontUrl?: FileLoaderOptions
-  imgUrl?: FileLoaderOptions
+  fontUrl?: UrlLoaderOptions
+  imgUrl?: UrlLoaderOptions
   less?: Less.Options
   pugPlain?: PugOptions
   sass?: SassOptions

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -22,12 +22,6 @@ import * as Less from 'less'
 import { Options as SassOptions } from 'node-sass'
 import { VueLoaderOptions } from 'vue-loader'
 
-interface FileLoaderOptions {
-  fallback?: string
-  limit?: number | boolean | string
-  mimetype?: string
-}
-
 type CssLoaderUrlFunction = (url: string, resourcePath: string) => boolean
 type CssLoaderImportFunction = (parsedImport: string, resourcePath: string) => boolean
 type CssLoaderMode = 'global' | 'local'


### PR DESCRIPTION
Previous PR erroneously used `FileLoaderOptions` instead of `UrlLoaderOptions` for `fontUrl` and `imgUrl` loaders. This fixes it.

Closes #221 