### PR TITLE
fix: import declaration conflicts with local declaration of 'FileLoaderOptions'

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -21,7 +21,7 @@ import * as Less from 'less'
 import { Options as SassOptions } from 'node-sass'
 import { VueLoaderOptions } from 'vue-loader'
 
-interface FileLoaderOptions {
+interface CustomFileLoaderOptions extends FileLoaderOptions {
   fallback?: string
   limit?: number | boolean | string
   mimetype?: string
@@ -52,9 +52,9 @@ interface CssLoaderOptions {
 interface NuxtConfigurationLoaders {
   css?: CssLoaderOptions
   cssModules?: CssLoaderOptions
-  file?: FileLoaderOptions
-  fontUrl?: FileLoaderOptions
-  imgUrl?: FileLoaderOptions
+  file?: CustomFileLoaderOptions
+  fontUrl?: CustomFileLoaderOptions
+  imgUrl?: CustomFileLoaderOptions
   less?: Less.Options
   pugPlain?: PugOptions
   sass?: SassOptions


### PR DESCRIPTION
Currently (with the latest release 0.4.0) I'm unable to compile my module, I had to downgrade again to get things running again.

I get the error with typescript 3.7.2:
```
ERROR in /home/simon/Dev/Web/hokify-frontend/node_modules/@nuxt/types/config/build.d.ts
ERROR in /home/simon/Dev/Web/hokify-frontend/node_modules/@nuxt/types/config/build.d.ts(18,10):
TS2440: Import declaration conflicts with local declaration of 'FileLoaderOptions'.
```

this is a possible fix for this, unsure why this type is overloaded herein first place, but as it is only an internal used one, I guess this fix will be good enough.