### PR TITLE
docs: add warning for programmatic usage

### DIFF
--- a/docs/guide/runtime.md
+++ b/docs/guide/runtime.md
@@ -42,3 +42,25 @@ All you need to do is update your **package.json** file:
 :::
 
 You can now use TypeScript for **nuxt.config** file, local **modules** and **serverMiddlewares**.
+
+::: warning
+
+`@nuxt/typescript-runtime` does not support programmatic usage (as it extends `@nuxt/cli`). 
+
+Advanced users might try adding the following code to your server entrypoint (see [source](https://github.com/nuxt/typescript/blob/master/packages/typescript-runtime/src/index.ts)):
+
+```js
+import { register } from 'ts-node'
+
+register({
+  project: 'tsconfig.json',
+  compilerOptions: {
+    module: 'commonjs'
+  }
+})
+```
+
+However, this is **not recommended or supported**.
+:::
+
+

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -71,6 +71,22 @@ and create a **`tsconfig.json`** file :
 Check official [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to learn about the different compiler options.
 :::
 
+::: warning
+
+If you are using Nuxt programmatically with a custom server framework, note that you will need to ensure that you wait for Nuxt to be ready before building:
+
+```js
+
+// Make sure to wait for Nuxt to load @nuxt/typescript-build before proceeding
+await nuxt.ready()
+...
+if (config.dev) {
+  const builder = new Builder(nuxt)
+  await builder.build()
+}
+```
+:::
+
 That's it, you're all set to use TypeScript in your **layouts**, **components**, **plugins** and **middlewares**.
 
 You can check the [**CookBook**](../cookbook/components/) section to get some TypeScript recipes for your Nuxt project.


### PR DESCRIPTION
1. Add warning to ensure to await Nuxt readiness - to ensure `@nuxt/typescript-build` is loaded before proceeding. It seems simple enough that I'm not sure we need a cookbook or more extended example - just works out-of-the-box if you do this.

2. Add example of how to use with TS config, locale modules or serverMiddleware - along with a warning that this is unsupported and for advanced users only.

closes #219, #193, #154, #139