### PR TITLE
docs: reorder yarn command to be before npm command

### DIFF
--- a/docs/guide/lint.md
+++ b/docs/guide/lint.md
@@ -11,9 +11,9 @@ If you're already using `@nuxtjs/eslint-config`, remove it from your dependencie
 :::
 
 ```sh
-npm i -D @nuxtjs/eslint-config-typescript
-# OR
 yarn add -D @nuxtjs/eslint-config-typescript
+# OR
+npm i -D @nuxtjs/eslint-config-typescript
 ```
 
 Then, create or edit your ESLint configuration `.eslintrc.js` by extending `@nuxtjs/eslint-config-typescript` :


### PR DESCRIPTION
In the previous steps (Setup and Runtime), the yarn command is given first. However, for the Lint step, it is the opposite. Having the commands in the same order across the steps would give a more consistent experience.