### PR TITLE
docs(cookbook/store): add reminder about axios accessor plugin

### DIFF
--- a/docs/cookbook/store.md
+++ b/docs/cookbook/store.md
@@ -64,6 +64,8 @@ For use with Nuxt, there are few key provisos:
    export default accessor
    ```
 
+   Don't forget to add the plugin to your `nuxt.config.js` file.
+
    `~/utils/api.ts`:
 
    ```ts


### PR DESCRIPTION
Just a little reminder to add the axios-accessor plugin to nuxt.config.js (which I personally forgot about, losing ~2hours in the process).