### PR TITLE
add consola to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/jest": "latest",
     "@vue/composition-api": "latest",
     "codecov": "latest",
-    "consola": "^2.11.3",
     "eslint": "latest",
     "husky": "latest",
     "jest": "latest",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "latest",
     "@vue/composition-api": "latest",
     "codecov": "latest",
+    "consola": "^2.11.3",
     "eslint": "latest",
     "husky": "latest",
     "jest": "latest",

--- a/packages/typescript-runtime/package.json
+++ b/packages/typescript-runtime/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@nuxt/types": "0.6.1",
+    "consola": "^2.11.3",
     "ts-node": "^8.6.2",
     "typescript": "~3.7"
   },


### PR DESCRIPTION
This pr adds `consola` to `@nuxt/typescript-runtime` dependencies, the idea behind it is to support nuxt projects using `yarn@berry` that requires [explicit requires](https://yarnpkg.com/advanced/migration#a-package-is-trying-to-access-another-package-)