### PR TITLE
Mistake in @nuxt/types: should rename UrlLoaderOptions.esModules to esModule

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -48,7 +48,7 @@ interface CssLoaderOptions {
 }
 
 interface UrlLoaderOptions {
-  esModules?: boolean
+  esModule?: boolean
   fallback?: WebpackLoader
   limit?: boolean | number | string
   mimetype?: string


### PR DESCRIPTION
UrlLoaderOptions should have `esModule` option, not `esModules`. Thanks @oppianmatt for finding this out!

Proof: https://github.com/webpack-contrib/url-loader#esmodule