### PR TITLE
fix(examples): use defineComponent in composition-api basic example

### DIFF
--- a/examples/composition-api/minimal/pages/index.vue
+++ b/examples/composition-api/minimal/pages/index.vue
@@ -5,9 +5,9 @@
 </template>
 
 <script lang="ts">
-import { createComponent, ref } from '@vue/composition-api'
+import { defineComponent, ref } from '@vue/composition-api'
 
-export default createComponent({
+export default defineComponent({
   setup () {
     const message = ref('This is a message')
 


### PR DESCRIPTION
## What does this fix?:

The composition-api example app is using `createComponent` in `pages/index.vue`.

`createComponent` has been deprecated and renamed to `defineComponent`.  See https://github.com/vuejs/vue-next/commit/1c4cdd841daa2ba9c1ec35068c92f1ae776cacea

This is a simple fix to the composition-api "basic" sandbox in Examples.

---

### Would the maintainers be open to the addition of more advanced composition-api examples?

I wasn't sure where else to ask this.

I would like to contribute an "advanced" example Nuxt app that contains full typescript support and testing with the composition API.  It would be a more generic version of my recent project: https://github.com/ShaggyTech/vin-decoder 

I use that as an example only to show that's it's possible to use typescript, jest and the composition-api together nicely.  I've really enjoyed the smooth development experience once project setup and configuration is sorted out.