### PR TITLE
fix(types): fix build.transpile type

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -171,7 +171,7 @@ export interface NuxtConfigurationBuild {
   standalone?: boolean
   templates?: any
   terser?: TerserPluginOptions | boolean
-  transpile?: Array<string | RegExp | ((context: NuxtWebpackEnv) => string | RegExp)>
+  transpile?: Array<string | RegExp | ((context: NuxtWebpackEnv) => string | RegExp | undefined)>
   warningIgnoreFilters?: Array<(warn: Warning) => boolean>
   watch?: string[]
 }


### PR DESCRIPTION
Under some condition may return `undefined` to skip exclude list
```typescript
  build: {
    transpile: [
      ({ isDev, isClient }) => (!isDev && isClient && 'autotrack') || undefined,
    ],
  },
```
Only transplie when is not `isDev` && `isClient`