### PR TITLE
fix(pkg): use commonjs export

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES6",
     "lib": ["dom", "esnext"],
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Resolving recent cjs/jest issues as if we mock or disable esm, we cannot use typescript-build anymore for fixtures