### PR TITLE
Follow the latest ForkTsCheckerWebpackPlugin doc

### DIFF
--- a/docs/shared/tsconfig.json
+++ b/docs/shared/tsconfig.json
@@ -14,6 +14,7 @@
     "sourceMap": true,
     "strict": true,
     "noEmit": true,
+    "importsNotUsedAsValues": "preserve",
     "baseUrl": ".",
     "paths": {
       "~/*": [


### PR DESCRIPTION
As https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#vuejs says, `"importsNotUsedAsValues": "preserve"` should be configured.