### PR TITLE
Update lint.md

### DIFF
--- a/docs/guide/lint.md
+++ b/docs/guide/lint.md
@@ -54,7 +54,7 @@ export default {
   typescript: {
     typeCheck: {
       eslint: {
-        files: './src/**/*.{ts,js,vue}'
+        files: './**/*.{ts,js,vue}'
       }
     }
   }


### PR DESCRIPTION
Using ./src is incorrect in a default nuxt enviroment created with nuxt-create-app.
When copy pasting this it will throw errors that it cant find any file matching this.