### PR TITLE
docs: update combined inject example

### DIFF
--- a/docs/cookbook/plugins.md
+++ b/docs/cookbook/plugins.md
@@ -79,18 +79,25 @@ export default Vue.extend({
 import { Plugin } from '@nuxt/types'
 
 declare module 'vue/types/vue' {
+  // this.$myInjectedFunction inside Vue components
   interface Vue {
     $myInjectedFunction(message: string): void
   }
 }
 
 declare module '@nuxt/types' {
+  // nuxtContext.app.$myInjectedFunction inside asyncData, fetch, plugins, middleware, nuxtServerInit
   interface NuxtAppOptions {
+    $myInjectedFunction(message: string): void
+  }
+  // nuxtContext.$myInjectedFunction
+  interface Context {
     $myInjectedFunction(message: string): void
   }
 }
 
 declare module 'vuex/types/index' {
+  // this.$myInjectedFunction inside Vuex stores
   interface Store<S> {
     $myInjectedFunction(message: string): void
   }


### PR DESCRIPTION
When using `inject`, the value is also injected into `Context` ([source](https://github.com/nuxt/nuxt.js/blob/128c9743c40bf776af428e5ed36ea1a09a0ef7b8/packages/vue-app/template/index.js#L178)), so it should be covered in combined inject example.