### PR TITLE
fix(typescript-build): wrong path for dependency

### DIFF
--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -73,7 +73,7 @@ const tsModule: Module<Options> = function (moduleOptions) {
     ))
 
     if (options.typeCheck && isClient && !isModern) {
-      const ForkTsCheckerWebpackPlugin = require(this.nuxt.resolver.resolveModule('fork-ts-checker-webpack-plugin'))
+      const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
       config.plugins!.push(new ForkTsCheckerWebpackPlugin(Object.assign({
         typescript: {
           configFile: path.resolve(this.options.rootDir!, 'tsconfig.json'),


### PR DESCRIPTION
By using the Nuxt's resolver, it was resolving to whatever version of the package `fork-ts-checker-webpack-plugin` npm or yarn would find. That happened because `@nuxt/core` (the package where the Nuxt's resolver is located) doesn't have `fork-ts-checker-webpack-plugin` as a declared dependency. The version installed by `@nuxt/typescript-build` wouldn't always be used if for instance another version of the dependency is also installed on the project.

This fixes #145.