### PR TITLE
corrected cookbook link

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -119,7 +119,7 @@ if (config.dev) {
 
 That's it, you're all set to use TypeScript in your **layouts**, **components**, **plugins** and **middlewares**.
 
-You can check the [**CookBook**](../cookbook/components/) section to get some TypeScript recipes for your Nuxt project.
+You can check the [**CookBook**](../../cookbook/components/) section to get some TypeScript recipes for your Nuxt project.
 
 ## Module options
 

--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -119,7 +119,7 @@ if (config.dev) {
 
 That's it, you're all set to use TypeScript in your **layouts**, **components**, **plugins** and **middlewares**.
 
-You can check the [**CookBook**](../../cookbook/components/) section to get some TypeScript recipes for your Nuxt project.
+You can check the [**CookBook**](/cookbook/components/) section to get some TypeScript recipes for your Nuxt project.
 
 ## Module options
 


### PR DESCRIPTION
The [guide](https://typescript.nuxtjs.org/guide/setup/) leads to [a 404](https://typescript.nuxtjs.org/guide/cookbook/components/), but instead should point [here](https://typescript.nuxtjs.org/cookbook/components/). Removing the `/guide` will fix the link.
I'm not sure how you parse this file (the header at the markdown beginning irritates me) and I didn't test this locally. If the change is wrong, at least it's kind of a bug report :sweat_smile: 