### PR TITLE
docs: adds instruction for including ESLint

### DIFF
--- a/docs/content/en/guide/lint.md
+++ b/docs/content/en/guide/lint.md
@@ -15,20 +15,22 @@ All you need is to install `@nuxtjs/eslint-config-typescript`:
 
 If you're already using `@nuxtjs/eslint-config`, remove it from your dependencies, the Nuxt TypeScript ESLint config includes it.
 
+If you have not yet done so, you must install ESLint separately.
+
 </alert>
 
 <code-group>
 <code-block label="Yarn" active>
 
 ```sh
-yarn add -D @nuxtjs/eslint-config-typescript
+yarn add -D @nuxtjs/eslint-config-typescript eslint
 ```
 
 </code-block>
 <code-block label="NPM">
 
 ```sh
-npm i -D @nuxtjs/eslint-config-typescript
+npm i -D @nuxtjs/eslint-config-typescript eslint
 ```
 
 </code-block>


### PR DESCRIPTION
If you do not have ESLint installed, you will get the following error.

```
✖ Nuxt Fatal Error
Error: When you use 'eslint' option, make sure to install 'eslint'.
```

If we add this to the instructions, then users can avoid this error.