### PR TITLE
docs: remove recommendation to use `nuxt-ts`

### DIFF
--- a/docs/content/en/guide/runtime.md
+++ b/docs/content/en/guide/runtime.md
@@ -40,10 +40,10 @@ All you need to do is update your **package.json** file:
 
 ```json{2-5}
 "scripts": {
-  "dev": "nuxt-ts",
-  "build": "nuxt-ts build",
-  "generate": "nuxt-ts generate",
-  "start": "nuxt-ts start"
+  "dev": "nuxt",
+  "build": "nuxt build",
+  "generate": "nuxt generate",
+  "start": "nuxt start"
 },
 "dependencies": {
   "@nuxt/typescript-runtime": "latest",
@@ -54,12 +54,6 @@ All you need to do is update your **package.json** file:
   "@nuxt/typescript-build": "latest"
 }
 ```
-
-<alert type="info">
-
-**nuxt-ts** also works if you're using edge version of Nuxt.js (**nuxt-edge**).
-
-</alert>
 
 You can now use TypeScript for **nuxt.config** file, local **modules** and **serverMiddlewares**.
 


### PR DESCRIPTION
If you try to use `nuxt-ts`, you receive the following error.

```
IMPORTANT : Package deprecation

Nuxt TypeScript Support has been refactored to be used with nuxt package.
Which means that nuxt-ts package is now no longer needed and is now tagged as deprecated.
We highly recommend to follow the guidelines below :

Migration guide (2.5.x)

Using yarn
yarn remove nuxt-ts
yarn add nuxt
yarn add -D @nuxt/typescript

Using npm
npm uninstall nuxt-ts
npm install nuxt
npm install -D @nuxt/typescript

 ----- nuxt.config.ts ----- 
| build: {                 |
| -- useForkTsChecker: ... |
| ++ typescript : {        |
| ++   typeCheck: ...      |
| ++ }                     |
| }                        |
 -------------------------- 
```