### PR TITLE
循環参照になる @nuxt/typescript-build の logger オプションを削除

### DIFF
--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -81,7 +81,8 @@ const tsModule: Module<Options> = function (moduleOptions) {
             vue: true
           }
         },
-        logger: consola.withScope('nuxt:typescript')
+        // FIXME: options for fork-ts-checker-webpack-plugin should be JSON stringify-able
+        // logger: consola.withScope('nuxt:typescript')
       } as TsCheckerOptions, options.typeCheck)))
     }
   })


### PR DESCRIPTION
次の issue の一時対応:

https://github.com/nuxt/typescript/issues/504