### PR TITLE
chore: add modules docs link

### DIFF
--- a/docs/content/en/cookbook/modules.md
+++ b/docs/content/en/cookbook/modules.md
@@ -24,3 +24,5 @@ export default myModule
 // REQUIRED if publishing the module as npm package
 // export const meta = require('./package.json')
 ```
+
+Read more about [modules property](https://nuxtjs.org/docs/configuration-glossary/configuration-modules/), [modules dir](https://nuxtjs.org/docs/directory-structure/modules/). 


### PR DESCRIPTION
Signed-off-by: Ayush P Gupta <ayushpguptaapg@gmail.com>

This PR aims at adding missing relevant docs link to modules page.
Although this is bare minimum needed, but i think we should extend docs more.
Let me know the plans.