### PR TITLE
fix: remove unused typings

### DIFF
--- a/docs/content/en/cookbook/plugins.md
+++ b/docs/content/en/cookbook/plugins.md
@@ -95,10 +95,6 @@ declare module '@nuxt/types' {
   interface NuxtAppOptions {
     $myInjectedFunction(message: string): void
   }
-  // nuxtContext.$myInjectedFunction
-  interface Context {
-    $myInjectedFunction(message: string): void
-  }
 }
 
 declare module 'vuex/types/index' {


### PR DESCRIPTION
Fixes #535 

Currently I have removed `Context` typing as `inject` only injects in `context.app`.

Note- This PR makes only changes in `en` content.