### PR TITLE
chore(deps): separate docs dependencies in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,21 @@
   "ignoreDeps": [
     "@nuxt/types",
     "typescript"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Docs dependencies",
+      "matchFiles": ["docs/package.json"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "lockFileMaintenance": {
+        "enabled": true,
+        "extends": [
+          "schedule:weekly"
+        ]
+      }
+    }
   ]
 }


### PR DESCRIPTION
Docs (docus) dependencies tend to be tricky so separate them so that those don't block other dep updates.