### PR TITLE
chore(deps): separate lock file updates per package.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
     "@nuxtjs"
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "branchTopic": "lock-file-maintenance-{{packageFile}}",
+    "commitMessageExtra": "({{packageFile}})"
   },
   "labels": [
     "dependencies"
@@ -15,17 +17,13 @@
   "packageRules": [
     {
       "groupName": "Docs dependencies",
-      "matchFiles": ["docs/package.json"],
+      "matchFiles": [
+        "docs/package.json"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ],
-      "lockFileMaintenance": {
-        "enabled": true,
-        "extends": [
-          "schedule:weekly"
-        ]
-      }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Since `docs` is "impossible" to update to latest nuxt/docus, separate those out so that we can update other lock files.

Based on https://github.com/renovatebot/config-help/issues/89