### PR TITLE
fix: deep merge user's module options

### DIFF
--- a/packages/typescript-build/package.json
+++ b/packages/typescript-build/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "consola": "^2.15.3",
+    "defu": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^6.5.3",
     "ts-loader": "^8.4.0"
   },

--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { defu } from 'defu'
 import consola from 'consola'
 import { Module } from '@nuxt/types'
 import { Options as TsLoaderOptions } from 'ts-loader'
@@ -27,11 +28,7 @@ const defaults: Options = {
 
 const tsModule: Module<Options> = function (moduleOptions) {
   // Combine options
-  const options = Object.assign(
-    defaults,
-    this.options.typescript,
-    moduleOptions
-  )
+  const options = defu(this.options.typescript, moduleOptions, defaults)
 
   // Change color of CLI banner
   this.options.cli.bannerColor = 'blue'
@@ -75,7 +72,7 @@ const tsModule: Module<Options> = function (moduleOptions) {
     if (options.typeCheck && isClient && !isModern) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
-      config.plugins!.push(new ForkTsCheckerWebpackPlugin(Object.assign({
+      config.plugins!.push(new ForkTsCheckerWebpackPlugin(defu(options.typeCheck, {
         typescript: {
           configFile: path.resolve(this.options.rootDir!, 'tsconfig.json'),
           extensions: {
@@ -83,7 +80,7 @@ const tsModule: Module<Options> = function (moduleOptions) {
           }
         },
         logger: consola.withScope('nuxt:typescript')
-      } as TsCheckerOptions, options.typeCheck)))
+      } as TsCheckerOptions)))
     }
   })
 }

--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { defu } from 'defu'
 import consola from 'consola'
 import { Module } from '@nuxt/types'

--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { defu } from 'defu'
 import consola from 'consola'
 import { Module } from '@nuxt/types'


### PR DESCRIPTION
User options were overwriting the defaults so it was not possible to override just some of the options.