### PR TITLE
fix(typescript-build): set logger instance correctly

### DIFF
--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -76,7 +76,7 @@ const tsModule: Module<Options> = function (moduleOptions) {
       const logger = consola.withTag('nuxt:typescript')
       const loggerInterface: TsCheckerLogger = {
         log (message) { logger.log(message) },
-        info () {},
+        info (message) { logger.info(message) },
         error (message) { logger.error(message) }
       }
       config.plugins!.push(new ForkTsCheckerWebpackPlugin(defu(options.typeCheck, {
@@ -87,7 +87,6 @@ const tsModule: Module<Options> = function (moduleOptions) {
           }
         },
         logger: {
-          infrastructure: loggerInterface,
           issues: loggerInterface
         }
       } as TsCheckerOptions)))

--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -74,6 +74,7 @@ const tsModule: Module<Options> = function (moduleOptions) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
       const logger = consola.withTag('nuxt:typescript')
+      /* istanbul ignore next */
       const loggerInterface: TsCheckerLogger = {
         log (message) { logger.log(message) },
         info (message) { logger.info(message) },

--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 import { defu } from 'defu'
 import consola from 'consola'
-import { Module } from '@nuxt/types'
-import { Options as TsLoaderOptions } from 'ts-loader'
-import { ForkTsCheckerWebpackPluginOptions as TsCheckerOptions } from 'fork-ts-checker-webpack-plugin/lib/ForkTsCheckerWebpackPluginOptions'
-import TsCheckerLogger from 'fork-ts-checker-webpack-plugin/lib/logger/Logger'
-import { RuleSetUseItem } from 'webpack'
+import type { Module } from '@nuxt/types'
+import type { Options as TsLoaderOptions } from 'ts-loader'
+import type { ForkTsCheckerWebpackPluginOptions as TsCheckerOptions } from 'fork-ts-checker-webpack-plugin/lib/ForkTsCheckerWebpackPluginOptions'
+import type TsCheckerLogger from 'fork-ts-checker-webpack-plugin/lib/logger/Logger'
+import type { RuleSetUseItem } from 'webpack'
 
 export interface Options {
   ignoreNotFoundWarnings?: boolean

--- a/packages/typescript-build/src/index.ts
+++ b/packages/typescript-build/src/index.ts
@@ -4,6 +4,7 @@ import consola from 'consola'
 import { Module } from '@nuxt/types'
 import { Options as TsLoaderOptions } from 'ts-loader'
 import { ForkTsCheckerWebpackPluginOptions as TsCheckerOptions } from 'fork-ts-checker-webpack-plugin/lib/ForkTsCheckerWebpackPluginOptions'
+import TsCheckerLogger from 'fork-ts-checker-webpack-plugin/lib/logger/Logger'
 import { RuleSetUseItem } from 'webpack'
 
 export interface Options {
@@ -72,6 +73,12 @@ const tsModule: Module<Options> = function (moduleOptions) {
     if (options.typeCheck && isClient && !isModern) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+      const logger = consola.withTag('nuxt:typescript')
+      const loggerInterface: TsCheckerLogger = {
+        log (message) { logger.log(message) },
+        info () {},
+        error (message) { logger.error(message) }
+      }
       config.plugins!.push(new ForkTsCheckerWebpackPlugin(defu(options.typeCheck, {
         typescript: {
           configFile: path.resolve(this.options.rootDir!, 'tsconfig.json'),
@@ -79,7 +86,10 @@ const tsModule: Module<Options> = function (moduleOptions) {
             vue: true
           }
         },
-        logger: consola.withScope('nuxt:typescript')
+        logger: {
+          infrastructure: loggerInterface,
+          issues: loggerInterface
+        }
       } as TsCheckerOptions)))
     }
   })


### PR DESCRIPTION
Instead of passing whole Consola instance to `fork-ts-checker-webpack-plugin` options, which can't be serialized and would crash when trying to use JSON.serialize on it (see how it can happen in the linked issue), pass only an interface with required methods.

Our custom `consola` was not used AT ALL before this change. It was not set in the correct place so `fork-ts-checker-webpack-plugin` ignored it completely and just logged errors using `console` API. So this is also fixed now, in addition to fixing the crash.

Fixes #504