### PR TITLE
fix(docs): change 'nuxt.config.js' to 'nuxt.config.ts'

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -61,7 +61,7 @@ Types versioning match Nuxt versioning since [2.13.0](https://github.com/nuxt/nu
 
 ## Configuration
 
-All you need to do is add **`@nuxt/typescript-build`** to your **`buildModules`** in **`nuxt.config.js`**
+All you need to do is add **`@nuxt/typescript-build`** to your **`buildModules`** in **`nuxt.config.ts`**
 
 ```ts {}[nuxt.config.ts]
 import type { NuxtConfig } from '@nuxt/types'

--- a/docs/content/es/guide/setup.md
+++ b/docs/content/es/guide/setup.md
@@ -52,7 +52,7 @@ El versionamiento de los types coincide con el versionamiento de Nuxt desde la v
 
 ## Configuración
 
-Todo lo que necesitas es agregar **`@nuxt/typescript-build`** a tus **`buildModules`** en **`nuxt.config.js`**
+Todo lo que necesitas es agregar **`@nuxt/typescript-build`** a tus **`buildModules`** en **`nuxt.config.ts`**
 
 ```ts {}[nuxt.config.ts]
 import type { NuxtConfig } from '@nuxt/types'

--- a/docs/content/ja/guide/setup.md
+++ b/docs/content/ja/guide/setup.md
@@ -30,7 +30,7 @@ npm install --save-dev @nuxt/typescript-build @nuxt/types
 
 ## 設定
 
-必要なことは、**`nuxt.config.js`** 内の **`buildModules`** に **`@nuxt/typescript-build`** を追加することです。
+必要なことは、**`nuxt.config.ts`** 内の **`buildModules`** に **`@nuxt/typescript-build`** を追加することです。
 
 ```ts {}[nuxt.config.ts]
 import type { NuxtConfig } from '@nuxt/types'

--- a/docs/content/pt/guide/setup.md
+++ b/docs/content/pt/guide/setup.md
@@ -61,7 +61,7 @@ O versionamento dos tipos corresponde ao versionamento do Nuxt desde [2.13.0](ht
 
 ## Configuração
 
-Tudo o que você precisa é adicionar **`@nuxt/typescript-build`** ao seu **`buildModules`**  no arquivo **`nuxt.config.js`**
+Tudo o que você precisa é adicionar **`@nuxt/typescript-build`** ao seu **`buildModules`**  no arquivo **`nuxt.config.ts`**
 
 ```ts {}[nuxt.config.ts]
 import type { NuxtConfig } from '@nuxt/types'

--- a/docs/content/zh-Hans/guide/setup.md
+++ b/docs/content/zh-Hans/guide/setup.md
@@ -30,7 +30,7 @@ npm install --save-dev @nuxt/typescript-build @nuxt/types
 
 ## 设置
 
-你只需在 **`nuxt.config.js`** 中的 **`buildModules`** 中加入 **`@nuxt/typescript-build`**
+你只需在 **`nuxt.config.ts`** 中的 **`buildModules`** 中加入 **`@nuxt/typescript-build`**
 
 ```ts {}[nuxt.config.ts]
 import type { NuxtConfig } from '@nuxt/types'

--- a/docs/content/zh-Hant/guide/setup.md
+++ b/docs/content/zh-Hant/guide/setup.md
@@ -30,7 +30,7 @@ npm install --save-dev @nuxt/typescript-build @nuxt/types
 
 ## 設定
 
-你只需要在 **`nuxt.config.js`** 中的 **`buildModules`** 中加入 **`@nuxt/typescript-build`**
+你只需要在 **`nuxt.config.ts`** 中的 **`buildModules`** 中加入 **`@nuxt/typescript-build`**
 
 ```ts {}[nuxt.config.ts]
 import type { NuxtConfig } from '@nuxt/types'


### PR DESCRIPTION
typo/self explanatory, 'import type' declarations can only be used in TypeScript files.