### PR TITLE
fix: extend typescript peer dependency range to include 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nuxt": "2.x",
     "sass": "^1.59.3",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.2",
     "vue-property-decorator": "^9.1.2"
   }
 }

--- a/packages/typescript-build/package.json
+++ b/packages/typescript-build/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@nuxt/types": ">=2.13.1",
-    "typescript": "4.x"
+    "typescript": "4.x || 5.x"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typescript-build/package.json
+++ b/packages/typescript-build/package.json
@@ -21,7 +21,7 @@
     "ts-loader": "^8.4.0"
   },
   "devDependencies": {
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.2"
   },
   "peerDependencies": {
     "@nuxt/types": ">=2.13.1",

--- a/packages/typescript-runtime/package.json
+++ b/packages/typescript-runtime/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "@nuxt/types": ">=2.13.1",
-    "typescript": "4.x"
+    "typescript": "4.x || 5.x"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11951,10 +11951,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@^3 || ^4", typescript@^4.9.5:
+"typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 ua-parser-js@^1.0.34:
   version "1.0.34"


### PR DESCRIPTION
After quick look there doesn't seem to be any apparent issues with TypeScript 5 so allow it in the peer dependency range.

Given that TypeScript doesn't really follow semantic versioning rules, it can break at any point but I still think that this is better approach then having to update this module on each TypeScript release. If new TS version breaks this module then we can restrict or fix it then.