### PR TITLE
chore(deps): use rangeStrategy "auto" for renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   },
   "devDependencies": {
     "@nuxt/types": "2.x",
-    "@nuxtjs/eslint-config-typescript": "^12.0.0",
-    "@types/jest": "^29.4.0",
-    "@vue/composition-api": "^1.7.1",
-    "codecov": "^3.8.3",
-    "eslint": "^8.36.0",
-    "jest": "^29.5.0",
-    "lerna": "^6.5.1",
+    "@nuxtjs/eslint-config-typescript": "12.0.0",
+    "@types/jest": "29.5.0",
+    "@vue/composition-api": "1.7.1",
+    "codecov": "3.8.3",
+    "eslint": "8.36.0",
+    "jest": "29.5.0",
+    "lerna": "6.5.1",
     "nuxt": "2.x",
-    "sass": "^1.59.3",
-    "ts-jest": "^29.0.5",
-    "typescript": "^5.0.2",
-    "vue-property-decorator": "^9.1.2"
+    "sass": "1.59.3",
+    "ts-jest": "29.0.5",
+    "typescript": "5.0.2",
+    "vue-property-decorator": "9.1.2"
   }
 }

--- a/packages/typescript-build/package.json
+++ b/packages/typescript-build/package.json
@@ -17,11 +17,11 @@
   "dependencies": {
     "consola": "^2.15.3",
     "defu": "^6.0.0",
-    "fork-ts-checker-webpack-plugin": "^6.5.3",
-    "ts-loader": "^8.4.0"
+    "fork-ts-checker-webpack-plugin": "6.5.3",
+    "ts-loader": "8.4.0"
   },
   "devDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "5.0.2"
   },
   "peerDependencies": {
     "@nuxt/types": ">=2.13.1",

--- a/packages/typescript-runtime/package.json
+++ b/packages/typescript-runtime/package.json
@@ -19,7 +19,7 @@
     "compile": "tsc"
   },
   "dependencies": {
-    "ts-node": "^9.1.1"
+    "ts-node": "9.1.1"
   },
   "peerDependencies": {
     "@nuxt/types": ">=2.13.1",

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "@nuxtjs"
   ],
+  "rangeStrategy": "auto",
   "lockFileMaintenance": {
     "enabled": true,
     "branchTopic": "lock-file-maintenance-{{packageFile}}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,7 +2095,7 @@
     webpack-node-externals "^3.0.0"
     webpackbar "^5.0.2"
 
-"@nuxtjs/eslint-config-typescript@^12.0.0":
+"@nuxtjs/eslint-config-typescript@12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-12.0.0.tgz#eaa36d8a8eb1c35a918f606e32613e0726b98c0b"
   integrity sha512-HJR0ho5MYuOCFjkL+eMX/VXbUwy36J12DUMVy+dj3Qz1GYHwX92Saxap3urFzr8oPkzzFiuOknDivfCeRBWakg==
@@ -2462,7 +2462,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^29.4.0":
+"@types/jest@29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.0.tgz#337b90bbcfe42158f39c2fb5619ad044bbb518ac"
   integrity sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==
@@ -2832,7 +2832,7 @@
   optionalDependencies:
     prettier "^1.18.2 || ^2.0.0"
 
-"@vue/composition-api@^1.7.1":
+"@vue/composition-api@1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.7.1.tgz#aa6831be5a12817d93e89e247460c310dd7a3a32"
   integrity sha512-xDWoEtxGXhH9Ku3ROYX/rzhcpt4v31hpPU5zF3UeVC/qxA3dChmqU8zvTUYoKh3j7rzpNsoFOwqsWG7XPMlaFA==


### PR DESCRIPTION
`@nuxtjs` renovate config [uses `"rangeStrategy": "bump"`](https://github.com/nuxt/renovate-config-nuxt/blob/40e1aa96888eccbcf2e5479a02f190b0910f9b1c/package.json#L36) which is not ideal for modules as it bumps range of `dependencies` which is more likely to result in duplicate copies of that dependency when Nuxt or other packages also depend on those.

With `"rangeStategy": "auto"`, [renovate will](https://docs.renovatebot.com/configuration-options/#rangestrategy) bump pinned dependencies but not range dependencies. This is more sane behavior for modules IMO.

Change to "auto" and update `package.json`s so that dependencies specific to this module and `devDependencies` are pinned and dependencies that are shared have wider ranges.